### PR TITLE
Improve JWT verification and add test endpoint

### DIFF
--- a/auth/jwt_config.php
+++ b/auth/jwt_config.php
@@ -7,9 +7,11 @@ use function OAuth\JWT\verify_jwt;
 */
 
 include_once __DIR__ . '/../vendor_load.php';
+include_once __DIR__ . '/config.php';
 
 use Firebase\JWT\JWT;
 use Firebase\JWT\ExpiredException;
+use Firebase\JWT\SignatureInvalidException;
 use Firebase\JWT\Key;
 
 function create_jwt(string $username): string
@@ -34,24 +36,25 @@ function create_jwt(string $username): string
 function verify_jwt(string $token)
 {
     global $jwt_key;
+    // [$verified, $error] = verify_jwt($text2);
 
     // Input validation
     if (empty($token) || empty($jwt_key)) {
         error_log('Token and JWT key are required');
-        return "";
+        return ["", 'Token and JWT key are required'];
     }
 
     try {
         $result = JWT::decode($token, new Key($jwt_key, 'HS256'));
-        return $result->username;
+        return [$result->username, ''];
     } catch (ExpiredException $e) {
         error_log('JWT token has expired');
-        return "";
-    } catch (Firebase\JWT\SignatureInvalidException $e) {
+        return ["", 'JWT token has expired'];
+    } catch (SignatureInvalidException $e) {
         error_log('JWT token signature is invalid');
-        return "";
+        return ["", 'JWT token signature is invalid'];
     } catch (\Exception $e) {
         error_log('Failed to verify JWT token: ' . $e->getMessage());
-        return "";
+        return ["", 'Failed to verify JWT token: ' . $e->getMessage()];
     }
 }

--- a/tests/jwt.php
+++ b/tests/jwt.php
@@ -5,12 +5,6 @@ include_once __DIR__ . '/../auth/jwt_config.php';
 
 use function OAuth\JWT\verify_jwt;
 
-if (!defined('global_username') || global_username !== 'Mr. Ibrahem') {
-    http_response_code(401);
-    echo json_encode(['message' => 'غير مصرح'], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
-    exit;
-}
-
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);

--- a/tests/jwt.php
+++ b/tests/jwt.php
@@ -1,0 +1,33 @@
+<?php
+
+include_once __DIR__ . '/../auth/jwt_config.php';
+
+use function OAuth\JWT\verify_jwt;
+
+ini_set('display_errors', 1);
+ini_set('display_startup_errors', 1);
+error_reporting(E_ALL);
+
+header('Content-Type: application/json');
+
+// تحقق من الهيدر "Authorization: Bearer TOKEN"
+$headers = getallheaders();
+
+if (!isset($headers['Authorization'])) {
+    http_response_code(401);
+    echo json_encode(['message' => 'رمز المصادقة مفقود'], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+    exit;
+}
+
+$authHeader = $headers['Authorization'];
+if (!preg_match('/Bearer\s(\S+)/', $authHeader, $matches)) {
+    http_response_code(401);
+    echo json_encode(['message' => 'صيغة رمز المصادقة غير صحيحة'], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+    exit;
+}
+
+$token = $matches[1];
+
+[$decoded, $error] = verify_jwt($token);
+
+echo json_encode([$decoded, $error], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);

--- a/tests/jwt.php
+++ b/tests/jwt.php
@@ -1,8 +1,15 @@
 <?php
 
+include_once __DIR__ . '/../auth/user_infos.php';
 include_once __DIR__ . '/../auth/jwt_config.php';
 
 use function OAuth\JWT\verify_jwt;
+
+if (!defined('global_username') || global_username !== 'Mr. Ibrahem') {
+    http_response_code(401);
+    echo json_encode(['message' => 'غير مصرح'], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+    exit;
+}
 
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);


### PR DESCRIPTION
Refactored verify_jwt to return both decoded username and error messages for better error handling. Added tests/jwt.php as an endpoint to validate JWT tokens from Authorization headers and return results in JSON, improving testability and API feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a standalone script for testing and verifying JWT authentication, providing detailed JSON error messages for various token issues.

- **Bug Fixes**
  - Improved error handling in JWT verification, now returning both the username and a descriptive error message for easier troubleshooting. 

- **Chores**
  - Enhanced input validation and logging for JWT authentication processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->