### PR TITLE
Load dev env and fallback env vars; fix path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ php -S localhost:8000
 ### Configuration
 
 Configuration is loaded from an INI file located at `$HOME/confs/OAuthConfig.ini`. Required keys:
-- `agent`, `consumerKey`, `consumerSecret` - OAuth credentials
+- `agent`, `$CONSUMER_KEY`, `$CONSUMER_SECRET` - OAuth credentials
 - `cookie_key`, `decrypt_key` - Defuse encryption keys (ASCII-safe format)
 - `jwt_key` - Secret for JWT signing
 

--- a/STATIC_ANALYSIS.md
+++ b/STATIC_ANALYSIS.md
@@ -426,8 +426,8 @@ if (session_status() === PHP_SESSION_NONE) session_start();
 $gUserAgent = '...';
 $oauthUrl = '...';
 $apiUrl = '...';
-$consumerKey = '...';
-$consumerSecret = '...';
+$CONSUMER_KEY = '...';
+$CONSUMER_SECRET = '...';
 $cookie_key = '...';
 $decrypt_key = '...';
 $jwt_key = '...';
@@ -528,7 +528,7 @@ $allowed_domains = ['mdwiki.toolforge.org', 'localhost'];  // login.php:61, logo
 
 ```php
 $conf = new ClientConfig($oauthUrl);
-$conf->setConsumer(new Consumer($consumerKey, $consumerSecret));
+$conf->setConsumer(new Consumer($CONSUMER_KEY, $CONSUMER_SECRET));
 $client = new Client($conf);
 ```
 

--- a/docs/new-structure-oc.md
+++ b/docs/new-structure-oc.md
@@ -417,8 +417,8 @@ location / {
 class Config {
     public function __construct(array $env) {
         $this->oauthUrl = $env['OAUTH_URL'];
-        $this->consumerKey = $env['OAUTH_CONSUMER_KEY'];
-        $this->consumerSecret = $env['OAUTH_CONSUMER_SECRET'];
+        $this->CONSUMER_KEY = $env['OAUTH_CONSUMER_KEY'];
+        $this->CONSUMER_SECRET = $env['OAUTH_CONSUMER_SECRET'];
         $this->jwtSecret = $env['JWT_SECRET'];
         $this->cookieKey = Key::loadFromAsciiSafeString($env['COOKIE_KEY']);
         $this->database = [

--- a/oauth/api.php
+++ b/oauth/api.php
@@ -24,7 +24,7 @@ include_once __DIR__ . '/helps.php';
 
 // Configure the OAuth client with the URL and consumer details.
 $conf = new ClientConfig($oauthUrl);
-$conf->setConsumer(new Consumer($consumerKey, $consumerSecret));
+$conf->setConsumer(new Consumer($CONSUMER_KEY, $CONSUMER_SECRET));
 $conf->setUserAgent($gUserAgent);
 $client = new Client($conf);
 // ---

--- a/oauth/callback.php
+++ b/oauth/callback.php
@@ -58,7 +58,7 @@ if (!isset($_SESSION['request_key'], $_SESSION['request_secret'])) {
 
 try {
     $conf = new ClientConfig($oauthUrl);
-    $conf->setConsumer(new Consumer($consumerKey, $consumerSecret));
+    $conf->setConsumer(new Consumer($CONSUMER_KEY, $CONSUMER_SECRET));
     $conf->setUserAgent($gUserAgent);
     $client = new Client($conf);
 } catch (\Exception $e) {

--- a/oauth/config.php
+++ b/oauth/config.php
@@ -1,9 +1,14 @@
 <?php
 //---
-include_once __DIR__ . '/../vendor_load.php';
-//---
 use Defuse\Crypto\Key;
 //---
+include_once __DIR__ . '/../vendor_load.php';
+//---
+$env = getenv('APP_ENV') ?: 'development';
+
+if ($env === 'development' && file_exists(__DIR__ . '/load_env.php')) {
+    include_once __DIR__ . '/load_env.php';
+}
 $domain = $_SERVER['SERVER_NAME'] ?? 'localhost';
 $gUserAgent = 'mdwiki MediaWiki OAuth Client/1.0';
 $oauthUrl = 'https://meta.wikimedia.org/w/index.php?title=Special:OAuth';
@@ -13,17 +18,17 @@ $apiUrl = preg_replace('/index\.php.*/', 'api.php', $oauthUrl);
 
 // ----------------
 // ----------------
-$CONSUMER_KEY        = getenv("CONSUMER_KEY") ?: '';
-$CONSUMER_SECRET     = getenv("CONSUMER_SECRET") ?: '';
-$COOKIE_KEY          = getenv("COOKIE_KEY") ?: '';
-$DECRYPT_KEY         = getenv("DECRYPT_KEY") ?: '';
-$JWT_KEY             = getenv("JWT_KEY") ?: '';
+$CONSUMER_KEY        = getenv("CONSUMER_KEY") ?: $_ENV['CONSUMER_KEY'] ?? '';
+$CONSUMER_SECRET     = getenv("CONSUMER_SECRET") ?: $_ENV['CONSUMER_SECRET'] ?? '';
+$COOKIE_KEY          = getenv("COOKIE_KEY") ?: $_ENV['COOKIE_KEY'] ?? '';
+$DECRYPT_KEY         = getenv("DECRYPT_KEY") ?: $_ENV['DECRYPT_KEY'] ?? '';
+$JWT_KEY             = getenv("JWT_KEY") ?: $_ENV['JWT_KEY'] ?? '';
 // ----------------
 // ----------------
 
 if (empty($CONSUMER_KEY) || empty($CONSUMER_SECRET)) {
     header("HTTP/1.1 500 Internal Server Error");
-    echo 'Required configuration directives not found in ini file';
+    error_log("Required configuration directives not found in environment variables!");
     exit(0);
 }
 

--- a/oauth/load_env.php
+++ b/oauth/load_env.php
@@ -93,6 +93,11 @@ try {
 
     // Define whitelist of allowed keys
     $whitelist = [
+        'CONSUMER_KEY',
+        'CONSUMER_SECRET',
+        'COOKIE_KEY',
+        'DECRYPT_KEY',
+        'JWT_KEY',
         'DB_HOST',
         'TOOL_TOOLSDB_USER',
         'TOOL_TOOLSDB_PASSWORD',

--- a/oauth/login.php
+++ b/oauth/login.php
@@ -33,7 +33,7 @@ function showErrorAndExit(string $message, ?string $linkUrl = null, ?string $lin
 // Configure the OAuth client with the URL and consumer details.
 try {
     $conf = new ClientConfig($oauthUrl);
-    $conf->setConsumer(new Consumer($consumerKey, $consumerSecret));
+    $conf->setConsumer(new Consumer($CONSUMER_KEY, $CONSUMER_SECRET));
     $conf->setUserAgent($gUserAgent);
     $client = new Client($conf);
 } catch (\Exception $e) {

--- a/oauth/send_edit.php
+++ b/oauth/send_edit.php
@@ -40,14 +40,14 @@ function get_edits_tokens($client, $accessToken, $apiUrl)
 
 function auth_make_edit($title, $text, $summary, $wiki, $access_key, $access_secret)
 {
-    global $gUserAgent, $consumerKey, $consumerSecret;
+    global $gUserAgent, $CONSUMER_KEY, $CONSUMER_SECRET;
     // ---
     $oauthUrl = "https://$wiki.wikipedia.org/w/index.php?title=Special:OAuth";
     $apiUrl = "https://$wiki.wikipedia.org/w/api.php";
     // ---
     // Configure the OAuth client with the URL and consumer details.
     $conf = new ClientConfig($oauthUrl);
-    $conf->setConsumer(new Consumer($consumerKey, $consumerSecret));
+    $conf->setConsumer(new Consumer($CONSUMER_KEY, $CONSUMER_SECRET));
     $conf->setUserAgent($gUserAgent);
     $client = new Client($conf);
     // ---

--- a/refactor.md
+++ b/refactor.md
@@ -165,8 +165,9 @@ if ($access == null) {
 $gUserAgent = '...';
 $oauthUrl = '...';
 $apiUrl = '...';
-$consumerKey = '...';
-$consumerSecret = '...';
+$CONSUMER_KEY        = getenv("CONSUMER_KEY") ?: '';
+$CONSUMER_SECRET     = getenv("CONSUMER_SECRET")
+?: '';
 $cookie_key = '...';
 $decrypt_key = '...';
 $jwt_key = '...';
@@ -357,7 +358,7 @@ namespace Auth\Config;
 
 class Config {
     private string $oauthUrl;
-    private string $consumerKey;
+    private string $CONSUMER_KEY;
     // ... other private properties
 
     public function __construct(string $environment) {
@@ -487,8 +488,8 @@ use Defuse\Crypto\Key;
 
 class Config {
     private string $oauthUrl;
-    private string $consumerKey;
-    private string $consumerSecret;
+    private string $CONSUMER_KEY;
+    private string $CONSUMER_SECRET;
     private Key $cookieKey;
     private Key $decryptKey;
     private string $jwtKey;
@@ -497,8 +498,8 @@ class Config {
 
     public function __construct(array $config) {
         $this->oauthUrl = $config['oauth_url'];
-        $this->consumerKey = $config['consumer_key'];
-        $this->consumerSecret = $config['consumer_secret'];
+        $this->CONSUMER_KEY = $config['consumer_key'];
+        $this->CONSUMER_SECRET = $config['consumer_secret'];
         $this->cookieKey = Key::loadFromAsciiSafeString($config['cookie_key']);
         $this->decryptKey = Key::loadFromAsciiSafeString($config['decrypt_key']);
         $this->jwtKey = $config['jwt_key'];
@@ -507,8 +508,8 @@ class Config {
     }
 
     public function getOAuthUrl(): string { return $this->oauthUrl; }
-    public function getConsumerKey(): string { return $this->consumerKey; }
-    public function getConsumerSecret(): string { return $this->consumerSecret; }
+    public function getConsumerKey(): string { return $this->CONSUMER_KEY; }
+    public function getConsumerSecret(): string { return $this->CONSUMER_SECRET; }
     public function getCookieKey(): Key { return $this->cookieKey; }
     public function getDecryptKey(): Key { return $this->decryptKey; }
     public function getJwtKey(): string { return $this->jwtKey; }
@@ -980,23 +981,24 @@ auth-repo/
 **Before:**
 ```php
 // oauth/config.php
-$consumerKey = $ini['consumerKey'] ?? '';
-$consumerSecret = $ini['consumerSecret'] ?? '';
+$CONSUMER_KEY        = getenv("CONSUMER_KEY") ?: '';
+$CONSUMER_SECRET     = getenv("CONSUMER_SECRET")
+?: '';
 
 // oauth/login.php
-global $consumerKey, $consumerSecret;
-$conf->setConsumer(new Consumer($consumerKey, $consumerSecret));
+global $CONSUMER_KEY, $CONSUMER_SECRET;
+$conf->setConsumer(new Consumer($CONSUMER_KEY, $CONSUMER_SECRET));
 ```
 
 **After:**
 ```php
 // config/Config.php
 class Config {
-    private string $consumerKey;
-    private string $consumerSecret;
+    private string $CONSUMER_KEY;
+    private string $CONSUMER_SECRET;
 
     public function getConsumerKey(): string {
-        return $this->consumerKey;
+        return $this->CONSUMER_KEY;
     }
 }
 

--- a/view.php
+++ b/view.php
@@ -1,7 +1,7 @@
 <?php
 
 if (substr(__DIR__, 0, 2) == 'I:') {
-	include_once __DIR__ . '/../../mdwiki/public_html/header.php';
+	include_once __DIR__ . '/../mdwiki/public_html/header.php';
 } else {
 	include_once __DIR__ . '/../header.php';
 }


### PR DESCRIPTION
Enable loading a local load_env.php in development by checking APP_ENV and including load_env.php if present. Use getenv() with $_ENV fallbacks for OAuth keys (CONSUMER_KEY, CONSUMER_SECRET, COOKIE_KEY, DECRYPT_KEY, JWT_KEY) and log an error when required keys are missing instead of echoing. Add those keys to the load_env.php whitelist so they can be loaded from the local env file. Also correct an include path in view.php to reference the mdwiki/public_html header. These changes improve local development setup and make environment loading more robust.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced environment configuration with conditional .env loading in development and improved logging for missing config.
  * Strengthened handling of sensitive auth/encryption keys via environment variables.
  * Adjusted header include paths for broader runtime compatibility.

* **Refactor**
  * OAuth consumer credential identifiers standardized/renamed to new uppercase keys.

* **Documentation**
  * Updated docs and samples to reflect the new configuration key names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->