### PR TITLE
Standardize OAuth Consumer Credentials naming and initialization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ php -S localhost:8000
 ### Configuration
 
 Configuration is loaded from an INI file located at `$HOME/confs/OAuthConfig.ini`. Required keys:
-- `agent`, `consumerKey`, `consumerSecret` - OAuth credentials
+- `agent`, `$CONSUMER_KEY`, `$CONSUMER_SECRET` - OAuth credentials
 - `cookie_key`, `decrypt_key` - Defuse encryption keys (ASCII-safe format)
 - `jwt_key` - Secret for JWT signing
 

--- a/STATIC_ANALYSIS.md
+++ b/STATIC_ANALYSIS.md
@@ -426,8 +426,8 @@ if (session_status() === PHP_SESSION_NONE) session_start();
 $gUserAgent = '...';
 $oauthUrl = '...';
 $apiUrl = '...';
-$consumerKey = '...';
-$consumerSecret = '...';
+$CONSUMER_KEY = '...';
+$CONSUMER_SECRET = '...';
 $cookie_key = '...';
 $decrypt_key = '...';
 $jwt_key = '...';
@@ -528,7 +528,7 @@ $allowed_domains = ['mdwiki.toolforge.org', 'localhost'];  // login.php:61, logo
 
 ```php
 $conf = new ClientConfig($oauthUrl);
-$conf->setConsumer(new Consumer($consumerKey, $consumerSecret));
+$conf->setConsumer(new Consumer($CONSUMER_KEY, $CONSUMER_SECRET));
 $client = new Client($conf);
 ```
 

--- a/docs/new-structure-oc.md
+++ b/docs/new-structure-oc.md
@@ -417,8 +417,8 @@ location / {
 class Config {
     public function __construct(array $env) {
         $this->oauthUrl = $env['OAUTH_URL'];
-        $this->consumerKey = $env['OAUTH_CONSUMER_KEY'];
-        $this->consumerSecret = $env['OAUTH_CONSUMER_SECRET'];
+        $this->CONSUMER_KEY = $env['OAUTH_CONSUMER_KEY'];
+        $this->CONSUMER_SECRET = $env['OAUTH_CONSUMER_SECRET'];
         $this->jwtSecret = $env['JWT_SECRET'];
         $this->cookieKey = Key::loadFromAsciiSafeString($env['COOKIE_KEY']);
         $this->database = [

--- a/oauth/api.php
+++ b/oauth/api.php
@@ -24,7 +24,7 @@ include_once __DIR__ . '/helps.php';
 
 // Configure the OAuth client with the URL and consumer details.
 $conf = new ClientConfig($oauthUrl);
-$conf->setConsumer(new Consumer($consumerKey, $consumerSecret));
+$conf->setConsumer(new Consumer($CONSUMER_KEY, $CONSUMER_SECRET));
 $conf->setUserAgent($gUserAgent);
 $client = new Client($conf);
 // ---

--- a/oauth/callback.php
+++ b/oauth/callback.php
@@ -58,7 +58,7 @@ if (!isset($_SESSION['request_key'], $_SESSION['request_secret'])) {
 
 try {
     $conf = new ClientConfig($oauthUrl);
-    $conf->setConsumer(new Consumer($consumerKey, $consumerSecret));
+    $conf->setConsumer(new Consumer($CONSUMER_KEY, $CONSUMER_SECRET));
     $conf->setUserAgent($gUserAgent);
     $client = new Client($conf);
 } catch (\Exception $e) {

--- a/oauth/config.php
+++ b/oauth/config.php
@@ -18,8 +18,8 @@ $apiUrl = preg_replace('/index\.php.*/', 'api.php', $oauthUrl);
 
 // ----------------
 // ----------------
-$CONSUMER_KEY        = getenv("CONSUMER_KEY") ?: '';
-$CONSUMER_SECRET     = getenv("CONSUMER_SECRET") ?: '';
+$CONSUMER_KEY        = getenv("CONSUMER_KEY") ?: $_ENV['CONSUMER_KEY'] ?? '';
+$CONSUMER_SECRET     = getenv("CONSUMER_SECRET") ?: $_ENV['CONSUMER_SECRET'] ?? '';
 $COOKIE_KEY          = getenv("COOKIE_KEY") ?: $_ENV['COOKIE_KEY'] ?? '';
 $DECRYPT_KEY         = getenv("DECRYPT_KEY") ?: $_ENV['DECRYPT_KEY'] ?? '';
 $JWT_KEY             = getenv("JWT_KEY") ?: $_ENV['JWT_KEY'] ?? '';

--- a/oauth/config.php
+++ b/oauth/config.php
@@ -18,8 +18,9 @@ $apiUrl = preg_replace('/index\.php.*/', 'api.php', $oauthUrl);
 
 // ----------------
 // ----------------
-$CONSUMER_KEY        = getenv("CONSUMER_KEY") ?: $_ENV['CONSUMER_KEY'] ?? '';
-$CONSUMER_SECRET     = getenv("CONSUMER_SECRET") ?: $_ENV['CONSUMER_SECRET'] ?? '';
+$CONSUMER_KEY        = getenv("CONSUMER_KEY") ?: '';
+$CONSUMER_SECRET     = getenv("CONSUMER_SECRET")
+?: '';
 $COOKIE_KEY          = getenv("COOKIE_KEY") ?: $_ENV['COOKIE_KEY'] ?? '';
 $DECRYPT_KEY         = getenv("DECRYPT_KEY") ?: $_ENV['DECRYPT_KEY'] ?? '';
 $JWT_KEY             = getenv("JWT_KEY") ?: $_ENV['JWT_KEY'] ?? '';

--- a/oauth/config.php
+++ b/oauth/config.php
@@ -19,8 +19,7 @@ $apiUrl = preg_replace('/index\.php.*/', 'api.php', $oauthUrl);
 // ----------------
 // ----------------
 $CONSUMER_KEY        = getenv("CONSUMER_KEY") ?: '';
-$CONSUMER_SECRET     = getenv("CONSUMER_SECRET")
-?: '';
+$CONSUMER_SECRET     = getenv("CONSUMER_SECRET") ?: '';
 $COOKIE_KEY          = getenv("COOKIE_KEY") ?: $_ENV['COOKIE_KEY'] ?? '';
 $DECRYPT_KEY         = getenv("DECRYPT_KEY") ?: $_ENV['DECRYPT_KEY'] ?? '';
 $JWT_KEY             = getenv("JWT_KEY") ?: $_ENV['JWT_KEY'] ?? '';

--- a/oauth/login.php
+++ b/oauth/login.php
@@ -33,7 +33,7 @@ function showErrorAndExit(string $message, ?string $linkUrl = null, ?string $lin
 // Configure the OAuth client with the URL and consumer details.
 try {
     $conf = new ClientConfig($oauthUrl);
-    $conf->setConsumer(new Consumer($consumerKey, $consumerSecret));
+    $conf->setConsumer(new Consumer($CONSUMER_KEY, $CONSUMER_SECRET));
     $conf->setUserAgent($gUserAgent);
     $client = new Client($conf);
 } catch (\Exception $e) {

--- a/oauth/send_edit.php
+++ b/oauth/send_edit.php
@@ -40,14 +40,14 @@ function get_edits_tokens($client, $accessToken, $apiUrl)
 
 function auth_make_edit($title, $text, $summary, $wiki, $access_key, $access_secret)
 {
-    global $gUserAgent, $consumerKey, $consumerSecret;
+    global $gUserAgent, $CONSUMER_KEY, $CONSUMER_SECRET;
     // ---
     $oauthUrl = "https://$wiki.wikipedia.org/w/index.php?title=Special:OAuth";
     $apiUrl = "https://$wiki.wikipedia.org/w/api.php";
     // ---
     // Configure the OAuth client with the URL and consumer details.
     $conf = new ClientConfig($oauthUrl);
-    $conf->setConsumer(new Consumer($consumerKey, $consumerSecret));
+    $conf->setConsumer(new Consumer($CONSUMER_KEY, $CONSUMER_SECRET));
     $conf->setUserAgent($gUserAgent);
     $client = new Client($conf);
     // ---

--- a/refactor.md
+++ b/refactor.md
@@ -165,8 +165,9 @@ if ($access == null) {
 $gUserAgent = '...';
 $oauthUrl = '...';
 $apiUrl = '...';
-$consumerKey = '...';
-$consumerSecret = '...';
+$CONSUMER_KEY        = getenv("CONSUMER_KEY") ?: '';
+$CONSUMER_SECRET     = getenv("CONSUMER_SECRET")
+?: '';
 $cookie_key = '...';
 $decrypt_key = '...';
 $jwt_key = '...';
@@ -357,7 +358,7 @@ namespace Auth\Config;
 
 class Config {
     private string $oauthUrl;
-    private string $consumerKey;
+    private string $CONSUMER_KEY;
     // ... other private properties
 
     public function __construct(string $environment) {
@@ -487,8 +488,8 @@ use Defuse\Crypto\Key;
 
 class Config {
     private string $oauthUrl;
-    private string $consumerKey;
-    private string $consumerSecret;
+    private string $CONSUMER_KEY;
+    private string $CONSUMER_SECRET;
     private Key $cookieKey;
     private Key $decryptKey;
     private string $jwtKey;
@@ -497,8 +498,8 @@ class Config {
 
     public function __construct(array $config) {
         $this->oauthUrl = $config['oauth_url'];
-        $this->consumerKey = $config['consumer_key'];
-        $this->consumerSecret = $config['consumer_secret'];
+        $this->CONSUMER_KEY = $config['consumer_key'];
+        $this->CONSUMER_SECRET = $config['consumer_secret'];
         $this->cookieKey = Key::loadFromAsciiSafeString($config['cookie_key']);
         $this->decryptKey = Key::loadFromAsciiSafeString($config['decrypt_key']);
         $this->jwtKey = $config['jwt_key'];
@@ -507,8 +508,8 @@ class Config {
     }
 
     public function getOAuthUrl(): string { return $this->oauthUrl; }
-    public function getConsumerKey(): string { return $this->consumerKey; }
-    public function getConsumerSecret(): string { return $this->consumerSecret; }
+    public function getConsumerKey(): string { return $this->CONSUMER_KEY; }
+    public function getConsumerSecret(): string { return $this->CONSUMER_SECRET; }
     public function getCookieKey(): Key { return $this->cookieKey; }
     public function getDecryptKey(): Key { return $this->decryptKey; }
     public function getJwtKey(): string { return $this->jwtKey; }
@@ -980,23 +981,24 @@ auth-repo/
 **Before:**
 ```php
 // oauth/config.php
-$consumerKey = $ini['consumerKey'] ?? '';
-$consumerSecret = $ini['consumerSecret'] ?? '';
+$CONSUMER_KEY        = getenv("CONSUMER_KEY") ?: '';
+$CONSUMER_SECRET     = getenv("CONSUMER_SECRET")
+?: '';
 
 // oauth/login.php
-global $consumerKey, $consumerSecret;
-$conf->setConsumer(new Consumer($consumerKey, $consumerSecret));
+global $CONSUMER_KEY, $CONSUMER_SECRET;
+$conf->setConsumer(new Consumer($CONSUMER_KEY, $CONSUMER_SECRET));
 ```
 
 **After:**
 ```php
 // config/Config.php
 class Config {
-    private string $consumerKey;
-    private string $consumerSecret;
+    private string $CONSUMER_KEY;
+    private string $CONSUMER_SECRET;
 
     public function getConsumerKey(): string {
-        return $this->consumerKey;
+        return $this->CONSUMER_KEY;
     }
 }
 


### PR DESCRIPTION
This change standardizes the OAuth consumer credentials across the codebase and documentation. It replaces the lowercase `$consumerKey` and `$consumerSecret` variables with uppercase `$CONSUMER_KEY` and `$CONSUMER_SECRET`, and updates their initialization in `oauth/config.php` to use the specific `getenv()` pattern requested. All affected PHP files and documentation were updated to ensure consistency.

---
*PR created automatically by Jules for task [16857600463986572847](https://jules.google.com/task/16857600463986572847) started by @MrIbrahem*