### PR TITLE
Use DB_HOST_TOOLS env var for DB host

### DIFF
--- a/src/oauth/mdwiki_sql.php
+++ b/src/oauth/mdwiki_sql.php
@@ -46,7 +46,7 @@ class Database
     }
     private function set_db(string $dbname_var)
     {
-        $this->host = $this->envVar('DB_HOST') ?: 'tools.db.svc.wikimedia.cloud';
+        $this->host = $this->envVar('DB_HOST_TOOLS') ?: 'tools.db.svc.wikimedia.cloud';
         $this->dbname = $this->envVar($dbname_var);
         $this->user = $this->envVar('TOOL_TOOLSDB_USER');
         $this->password = $this->envVar('TOOL_TOOLSDB_PASSWORD');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 // Set test environment
 putenv('APP_ENV=testing');
-putenv('DB_HOST=localhost:3306');
+putenv('DB_HOST_TOOLS=localhost:3306');
 putenv('DB_NAME=s54732__mdwiki');
 putenv('DB_NAME_NEW=s54732__mdwiki_new');
 putenv('TOOL_TOOLSDB_USER=root');


### PR DESCRIPTION
Switch the database host environment variable from DB_HOST to DB_HOST_TOOLS in Database::set_db, defaulting to tools.db.svc.wikimedia.cloud. Update test bootstrap to set DB_HOST_TOOLS=localhost:3306 so tests target the correct tools DB host.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database host configuration settings across the application and testing environments for consistent infrastructure management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->